### PR TITLE
add Jordan Wigner for the polarizable embedding Hamiltonian

### DIFF
--- a/cudaqlib/operators/fermion/fermion_op.h
+++ b/cudaqlib/operators/fermion/fermion_op.h
@@ -66,10 +66,10 @@ public:
 /// fermionic Hamiltonian.
 class fermion_op {
 public:
-  /// @brief The one-body overlap integrals, `h[p,q]`.
+  /// @brief The one-body integrals, `h[p,q]`.
   one_body_integrals hpq;
 
-  /// @brief The two-body overlap integrals, `h[p,q,r,s]`.
+  /// @brief The two-body integrals, `h[p,q,r,s]`.
   two_body_integrals hpqrs;
 
   /// @brief The constant energy term.
@@ -79,6 +79,20 @@ public:
       : hpq(one_body_integrals({numQubits, numQubits})),
         hpqrs(two_body_integrals({numQubits, numQubits, numQubits, numQubits})),
         constant(c) {}
+};
+
+/// @brief The `fermion_pe_op` is a simple wrapper around one
+/// body integral tensors describing a second quantized
+/// fermionic of the polarizable embedding Hamiltonian.
+
+class fermion_pe_op{
+  public:
+  /// @brief The one-body integrals, `h[p,q]`.
+  one_body_integrals vpq;
+
+  fermion_pe_op(std::size_t numQubits)
+      : vpq(one_body_integrals({numQubits, numQubits})){}
+
 };
 
 } // namespace cudaq::operators

--- a/cudaqlib/operators/fermion/transformations/jordan_wigner.cpp
+++ b/cudaqlib/operators/fermion/transformations/jordan_wigner.cpp
@@ -382,7 +382,7 @@ spin_op jordan_wigner::generate(const fermion_op &fermionOp) {
   return op;
 }
 
-spin_op jordan_wigner_pe::generate(const fermion_op &fermionOp){
+spin_op jordan_wigner_pe::generate(const fermion_pe_op &fermionOp){
   
   auto spin_hamiltonian = 0.0;
   std::size_t nqubit = fermionOp.vpq.shape[0];


### PR DESCRIPTION
This PR will allow computation of the qubit Hamiltonian for the polarizable embedding Hamiltonian.

1- Update  jordan_wigner.cpp (done)
2- Update Jordan_wigner.h (?)
3- Update fermion_op.h (done)
4- Update fermi_to_spin.h (?)